### PR TITLE
Updated deprecated pandas syntax

### DIFF
--- a/utility.py
+++ b/utility.py
@@ -666,7 +666,7 @@ class Utils:
             # restructuring the download report for this ncode
             ncode_dataframe = pd.DataFrame([])
             for data_json in ncode_report:
-                ncode_dataframe = ncode_dataframe.append(data_json, ignore_index=True)
+                ncode_dataframe = pd.concat([ncode_dataframe, pd.DataFrame([data_json])], ignore_index=True)
             ncode_report_csv_path = os.path.join(folder_path, category_name + "_download_report.csv")
             ncode_dataframe.to_csv(ncode_report_csv_path, index=False)
             print("Download complete in {} secs\n\n".format(time.time() - total_start_time))


### PR DESCRIPTION
I replaced the append code to match newer pandas syntax. (Python 3.12.4, Pandas 2.2.3) 

For more info see: https://stackoverflow.com/questions/75956209/error-dataframe-object-has-no-attribute-append 